### PR TITLE
Implement cast() methods for some spells 

### DIFF
--- a/backend/board.py
+++ b/backend/board.py
@@ -95,7 +95,7 @@ class Board(object):
 
     def get_placed_objects(self):
         # return all objects currently placed on board
-        return [art for art in self.artworks if art.hex] + [player for player in self.players if player.hex]
+        return [art for art in self.artworks if art.hex] + [player for player in self.players.values() if player.hex]
 
     def get_placed_non_player_objects(self):
         return [obj for obj in self.get_placed_objects() if obj != self.get_current_player]        

--- a/backend/board.py
+++ b/backend/board.py
@@ -3,6 +3,7 @@ Overall board class to store past and current game state.
 """
 import numpy as np
 
+from backend.errors import InvalidMove
 from backend.artwork import Artwork
 from backend.helpers import display_list, other_faction
 from backend.player import Player
@@ -98,7 +99,7 @@ class Board(object):
         return [art for art in self.artworks if art.hex] + [player for player in self.players.values() if player.hex]
 
     def get_placed_non_player_objects(self):
-        return [obj for obj in self.get_placed_objects() if obj != self.get_current_player]        
+        return [obj for obj in self.get_placed_objects() if obj != self.get_current_player()]        
 
     ######################
     # board layout methods
@@ -158,6 +159,27 @@ class Board(object):
         self.actions = 3
         [spell.untap() for spell in self.spells]
         self.faction = other_faction(self.faction)
+
+    #####################################
+    # dynamic gameplay methods
+    ##################################### 
+
+    def move_object(self, occupant, from_hex=None, to_hex=None):
+            # order matters here, updating occupant.hex last make it ok for from_hex to be occupant.hex initially
+            if from_hex != None:
+                from_hex.occupant = None
+            if to_hex != None:
+                if to_hex.occupant != None:
+                    raise InvalidMove('You\'re trying to move onto an occupied hex.')
+                to_hex.occupant = occupant
+            occupant.hex = to_hex
+    
+    def swap_object(self, object1, object2):
+        hex_1 = object1.hex
+        object1.hex = object2.hex
+        object2.hex = hex_1
+        object2.hex.occupant = object2
+        object1.hex.occupant = object1
 
     ##########################
     # string to object methods

--- a/backend/board.py
+++ b/backend/board.py
@@ -87,6 +87,19 @@ class Board(object):
     def get_current_player(self):
         return self.players[self.faction]
 
+    def get_opposing_player(self):
+        if self.faction == 'Light':
+            return self.players['Dark']
+        else:
+            return self.players['Light']
+
+    def get_placed_objects(self):
+        # return all objects currently placed on board
+        return [art for art in self.artworks if art.hex] + [player for player in self.players if player.hex]
+
+    def get_placed_non_player_objects(self):
+        return [obj for obj in self.get_placed_objects() if obj != self.get_current_player]        
+
     ######################
     # board layout methods
     ######################

--- a/backend/game.py
+++ b/backend/game.py
@@ -54,7 +54,7 @@ class Game(object):
             
         
         self.current_board.actions -= 1
-        self.move_object(player, from_hex=player.hex, to_hex=hex)
+        self.current_board.move_object(player, from_hex=player.hex, to_hex=hex)
 
     def bless(self):
         player = self.get_current_player()
@@ -94,6 +94,8 @@ class Game(object):
         for artwork in self.current_board.artworks:
             if artwork.faction == faction and artwork.hex == None:
                 eligible_artworks.append(artwork)
+        if len(eligible_artworks) == 0:
+            raise InvalidMove('{} does not have any unplaced artworks'.format(faction))
 
         hex = screen_input.choose_from_list(self.graphics, adj_hexes_wo_objs)
         if not hex:
@@ -110,13 +112,12 @@ class Game(object):
             print('Dropping {}'.format(artwork))
             
         self.current_board.actions -= 1
-        self.move_object(artwork, to_hex=hex)
+        self.current_board.move_object(artwork, to_hex=hex)
 
     def pick_up(self):
         if self.current_board.actions < 1:
             raise InvalidMove('You cannot pick up because you have no more actions')
-        print('You want to pick up but that\'s not implemented yet... skipping')
-
+        
         # get list of eligible hexes
         player = self.get_current_player()
         adj_hexes = find_adjacent_hexes(self.current_board, player.hex)
@@ -135,7 +136,7 @@ class Game(object):
         print('Picking up {}'.format(artwork))
         
         self.current_board.actions -= 1
-        self.move_object(artwork, from_hex=artwork.hex)
+        self.current_board.move_object(artwork, from_hex=artwork.hex)
 
     def cast_spell(self):
         spell = screen_input.choose_spell(self.graphics, self.current_board)
@@ -190,16 +191,9 @@ class Game(object):
         hex1 = self.current_board.rooms[0].hexes[0]
         hex2 = self.current_board.rooms[0].hexes[1]
 
-        self.move_object(light_player, to_hex=hex1)
-        self.move_object(dark_player, to_hex=hex2)
+        self.current_board.move_object(light_player, to_hex=hex1)
+        self.current_board.move_object(dark_player, to_hex=hex2)
 
-    def move_object(self, occupant, from_hex=None, to_hex=None):
-        # order matters here, updating occupant.hex last make it ok for from_hex to be occupant.hex initially
-        if from_hex != None:
-            from_hex.occupant = None
-        if to_hex != None:
-            to_hex.occupant = occupant
-        occupant.hex = to_hex
 
     def play(self):
         # set up board

--- a/backend/game.py
+++ b/backend/game.py
@@ -46,14 +46,13 @@ class Game(object):
         adj_hexes_wo_objs = [h for h in adj_hexes if h.occupant == None]
         # TODO: make functions in location.py to do ^ filtering + its opposite
 
-        if len(adj_hexes_wo_objs) == 0:
+        hex = screen_input.choose_from_list(self.graphics, adj_hexes_wo_objs)
+        if not hex:
             raise InvalidMove('There is no adjacent hex for you to move')
-        elif len(adj_hexes_wo_objs) == 1:
-            hex = adj_hexes_wo_objs[0]
-            print('Moving to {}'.format(hex))
         else:
-            hex = screen_input.choose_from_list(self.graphics, adj_hexes_wo_objs)
-
+            print('Moving to {}'.format(hex))
+            
+        
         self.current_board.actions -= 1
         self.move_object(player, from_hex=player.hex, to_hex=hex)
 
@@ -95,23 +94,21 @@ class Game(object):
         for artwork in self.current_board.artworks:
             if artwork.faction == faction and artwork.hex == None:
                 eligible_artworks.append(artwork)
-        if len(eligible_artworks) == 0:
-            raise InvalidMove('{} does not have any unplaced artworks'.format(faction))
 
-        # prompt for hex choice if needed
-        if len(adj_hexes_wo_objs) == 1:
-            hex = adj_hexes_wo_objs[0]
-            print('Dropping on {}'.format(hex))
+        hex = screen_input.choose_from_list(self.graphics, adj_hexes_wo_objs)
+        if not hex:
+            raise InvalidMove('There are no unoccupied hexes on which to drop')
         else:
-            hex = screen_input.choose_from_list(self.graphics, adj_hexes_wo_objs)
+            print('Dropping on {}'.format(hex))
+
 
         # prompt for artwork choice if needed
-        if len(eligible_artworks) == 1:
-            artwork = eligible_artworks[0]
-            print('Dropping {}'.format(artwork))
+        artwork = screen_input.choose_from_list(self.graphics, eligible_artworks)
+        if not artwork:
+            raise InvalidMove('{} does not have any unplaced artworks'.format(faction))
         else:
-            artwork = screen_input.choose_from_list(self.graphics, eligible_artworks)
-
+            print('Dropping {}'.format(artwork))
+            
         self.current_board.actions -= 1
         self.move_object(artwork, to_hex=hex)
 
@@ -130,16 +127,13 @@ class Game(object):
         for artwork in self.current_board.artworks:
             if artwork.faction == faction and artwork.hex in adj_hexes:
                 eligible_artworks.append(artwork)
-        if len(eligible_artworks) == 0:
-            raise InvalidMove('{} does not have any adjacent artworks to pick up'.format(faction))
-
+        
         # prompt for artwork choice if needed
-        if len(eligible_artworks) == 1:
-            artwork = eligible_artworks[0]
-            print('Picking up {}'.format(artwork))
-        else:
-            artwork = screen_input.choose_from_list(self.graphics, eligible_artworks)
-
+        artwork = screen_input.choose_from_list(self.graphics, eligible_artworks)
+        if not artwork:
+            raise InvalidMove('{} does not have any adjacent artworks to pick up'.format(faction))
+        print('Picking up {}'.format(artwork))
+        
         self.current_board.actions -= 1
         self.move_object(artwork, from_hex=artwork.hex)
 

--- a/backend/hex.py
+++ b/backend/hex.py
@@ -17,12 +17,12 @@ class Hex(object):
         )
 
     def toggle_aura(self):
-        if self.aura == None:
-            self.aura = "Dark"
-        elif self.aura == "Dark":
+        if self.aura == "Dark":
             self.aura = "Light"
         elif self.aura == "Light":
-            self.aura = None
+            self.aura = "Dark"
+        elif self.aura == None:
+            pass
         else:
             raise NameError('Hex cannot have aura value "{}".'.format(self.aura))
 

--- a/backend/location.py
+++ b/backend/location.py
@@ -30,9 +30,9 @@ def find_neighbor_hex(board, starting_hex, direction):
     #find the hex at direction relative to direction
     return find_hex(board, starting_hex.location + direction)
 
-def find_adjacent_hexes(board, starting_hex):
+def find_adjacent_hexes(board, starting_hex, return_nones = False):
     #given a hex, return the (up to six) neighboring hexes
-    return [ item for item in  [find_neighbor_hex(board,starting_hex,u) for u in unit_directions] if item != None]
+    return [ item for item in  [find_neighbor_hex(board,starting_hex,u) for u in unit_directions] if (item != None or return_nones)]
 
 def leap_eligible(board, hex1, hex2):
     if hex1 == hex2:
@@ -84,6 +84,16 @@ def linked_hexes(board, starting_hex):
 def adjacent_linked_region(board, starting_hex):
     # search for linked hexes, check if they are the same aura, and return the boundary
     return linked_search(board, starting_hex, True, True)
+
+def linked_rooms(board, starting_hex):
+    linked_hex = linked_hexes(board,starting_hex)
+    linked_room = []
+    for room in board.rooms:
+        for test_hex in room.hexes:
+            if test_hex in linked_hex:
+                linked_room.append(room)
+                break
+    return linked_room
 
 def neighboring_region(board, hex_list):
     neighbors = []

--- a/backend/location.py
+++ b/backend/location.py
@@ -35,13 +35,16 @@ def find_adjacent_hexes(board, starting_hex):
     return [ item for item in  [find_neighbor_hex(board,starting_hex,u) for u in unit_directions] if item != None]
 
 def leap_eligible(board, hex1, hex2):
+    if hex1 == hex2:
+        return False
     #returns true if two pieces on hex1 and hex2 can Leap, and false otherwise
     try:
         displacement = hex1.location - hex2.location
     except AttributeError:
         print("You tried to leap, but passed nonexistent hexes or locations. Shame on you.")
         return False
-    number_of_tiles = np.gcd.reduce([x for x in displacement.flat if x != 0])
+    nonzero_entries = [x for x in displacement.flat if x != 0]
+    number_of_tiles = np.gcd.reduce(nonzero_entries)
     u = (1/number_of_tiles) * displacement
     return not (None in [find_hex(board, hex2.location + i*u) for i in range(number_of_tiles)])
 

--- a/backend/location.py
+++ b/backend/location.py
@@ -26,9 +26,13 @@ def find_hex(board, location):
                 return test_hex
     return None
 
+def find_neighbor_hex(board, starting_hex, direction):
+    #find the hex at direction relative to direction
+    return find_hex(board, starting_hex.location + direction)
+
 def find_adjacent_hexes(board, starting_hex):
     #given a hex, return the (up to six) neighboring hexes
-    return [ item for item in  [find_hex(board, starting_hex.location + u) for u in unit_directions] if item != None]
+    return [ item for item in  [find_neighbor_hex(board,starting_hex,u) for u in unit_directions] if item != None]
 
 def leap_eligible(board, hex1, hex2):
     #returns true if two pieces on hex1 and hex2 can Leap, and false otherwise

--- a/backend/screen_input.py
+++ b/backend/screen_input.py
@@ -45,8 +45,14 @@ def choose_move(app, board):
 Params: list of objects
 Returns: chosen object
 '''
-# TODO: add a param that lets you modify the prompt
-def choose_from_list(app, ls):
+def choose_from_list(app, ls, prompt_text=None):
+    if len(ls) == 0:
+        return None
+    elif len(ls) == 1:
+        return ls[0]
+    if prompt_text:
+        # print optional prompt
+        print(prompt_text)
     while True:
         for idx, obj in enumerate(ls):
             print(' ({}) {}'.format(idx + 1, obj))

--- a/backend/spell.py
+++ b/backend/spell.py
@@ -299,7 +299,7 @@ class Leap(Spell):
         if not hex_str:
             # get list of leap-able objects
             leapable_objects = [obj for obj in board.get_placed_non_player_objects() if location.leap_eligible(board, board.get_current_player().hex, obj.hex)]
-            target_object = choose_from_list(leapable_objects)
+            target_object = choose_from_list(leapable_objects, 'Pick an object to Leap with')
             if not target_object:
                 raise InvalidMove('There\'s no object to Leap with')
         
@@ -330,20 +330,23 @@ class Yoke(Spell):
     def cast(self, board, hex_str = None):
         if not hex_str:
             # get target object for yoking
-            target_object = choose_from_list(board.get_placed_non_player_objects())
+            target_object = choose_from_list(board.get_placed_non_player_objects(), 'Pick an object to Yoke with')
             if not target_object:
                 # you shouldn't be here: there should always be at least two objects
                 raise InvalidMove('There was no other object to Yoke')
             # get directions for yolking
             possible_directions = []
             for u in location.unit_directions:
-                player_can_move = not(location.find_neighbor_hex(board, board.get_current_player().hex, u).occupant)
-                target_can_move = not(location.find_neighbor_hex(board, target_object.hex, u).occupant)
+                player_destination = location.find_neighbor_hex(board, board.get_current_player().hex, u)
+                target_destination = location.find_neighbor_hex(board, target_object.hex, u)
+
+                player_can_move = player_destination and not(player_destination.occupant)
+                target_can_move = target_destination and not(target_destination.occupant)
                 if (player_can_move and target_can_move):
                     possible_directions.append(u)
             # if there's more than one direction, ask user for input
             target_direction = choose_from_list(possible_directions)
-            if not target_direction:
+            if (target_direction == None).any():
                 raise InvalidMove('These two objects have no common direction to move')
 
         # TODO: implement movement

--- a/backend/user_input.py
+++ b/backend/user_input.py
@@ -58,6 +58,10 @@ Params: list of objects
 Returns: chosen object
 '''
 def choose_from_list(ls):
+    if len(ls) == 0:
+        return None
+    elif len(ls) == 1:
+        return ls[0]
     while True:
         for idx, obj in enumerate(ls):
             print(' ({}) {}'.format(idx + 1, obj))

--- a/backend/user_input.py
+++ b/backend/user_input.py
@@ -57,11 +57,14 @@ def choose_hex(board):
 Params: list of objects
 Returns: chosen object
 '''
-def choose_from_list(ls):
+def choose_from_list(ls, prompt_text = None):
     if len(ls) == 0:
         return None
     elif len(ls) == 1:
         return ls[0]
+    if prompt_text:
+        # print optional prompt
+        print(prompt_text)
     while True:
         for idx, obj in enumerate(ls):
             print(' ({}) {}'.format(idx + 1, obj))


### PR DESCRIPTION
`backend/spell.py`

Cast methods for

- Priestess
- Imposter (needs testing)
- Imprint (needs testing)
- Usurper (needs testing)
- Upset (needs testing)
- Locksmith (needs testing)
- Leap (testing)

and some progress on Yeoman. Testing these spells will be much easier once we have a working GUI.

`backend/location.py`
 
 - linked_rooms() finds rooms linked to a hex

`backend/board.py`

- move_object() moved from game.py
- swap_object()

`backend/user_input.py`, `backend/screen_input.py`, `backend/game.py`

 - `choose_from_list` doesn't make the user choose from lists of length 0 or 1, and takes optional prompt_text as input

`backend/board.py`

- `get_placed_objects()` returns all objects currently placed on the board, and similar helper functions