### PR TITLE
Hexagonal tiles, prompt text and buttons on screen

### DIFF
--- a/backend/board.py
+++ b/backend/board.py
@@ -64,65 +64,55 @@ class Board(object):
             Yoke(),
         ]
         self.rooms = rooms or [
-            # P
-            Room('P', np.matrix([0,0,0]),
+            Room('P', np.matrix([1,2,-3]),
                 [   np.matrix([1,0,-1]),
                     np.matrix([0,1,-1]),
                     np.matrix([0,-1,1])
                 ], self.spells[0], self.spells[1]
             ),
-            # I
             Room('I', np.matrix([2,-2,0]),
                 [   np.matrix([0,1,-1]),
                     np.matrix([0,2,-2]),
                     np.matrix([0,3,-3])
                 ], self.spells[2], self.spells[3]
             ),
-            # O
             Room('O', np.matrix([3,-1,-2]),
                 [   np.matrix([0,-1,1]),
                     np.matrix([1,-1,0]),
                     np.matrix([1,-2,1])
                 ],  self.spells[4], self.spells[5]
             ),
-            # U 
             Room('U', np.matrix([3,0,-3]),
                 [   np.matrix([0,1,-1]),
                     np.matrix([1,1,-2]),
                     np.matrix([2,0,-2])
                 ],  self.spells[6],self.spells[7]
-            
             ),
-            # S
             Room('S', np.matrix([6,-3,-3]),
                 [   np.matrix([1,0,-1]),
                     np.matrix([1,1,-2]),
                     np.matrix([2,1,-3])
                 ],  self.spells[8], self.spells[9]
             ),
-            # L
             Room('L', np.matrix([5,-3,-2]),
                 [   np.matrix([0,1,-1]),
                     np.matrix([0,2,-2]),
-                    np.matrix([1,2,-3])
+                    np.matrix([-1,3,-2])
                 ], self.spells[10], self.spells[11]
             ),
-            # Y 
             Room('Y', np.matrix([7,0,-7]),
                 [   np.matrix([0,1,-1]),
                     np.matrix([1,-1,0]),
                     np.matrix([-1,0,1])
                 ], self.spells[12], self.spells[13]
-            
             )
         ]
 
     def __str__(self):
-        return '\n***BOARD***\n{faction}\'s turn\nactions:{actions}\nplayers:{players}\nspells:{spells}\nartworks:{artworks}\n***********\n'.format(
+        return '\n***BOARD***\n{faction}\'s turn\nactions:{actions}\nplayers:{players}\nartworks:{artworks}\n***********\n'.format(
             faction = self.faction,
             actions = self.actions,
             players = display_list(self.players.values()),
-            spells = display_list(self.spells),
             artworks = display_list(self.artworks),
         )
 
@@ -142,6 +132,27 @@ class Board(object):
 
     def get_opposing_player(self):
         return self.players[other_faction(self.faction)]
+
+    def get_state_msg(self):
+        turn = '{}\'s turn'.format(self.faction)
+        actions = '{} action{} left'.format(
+            self.actions,
+            '' if self.actions == 1 else 's',
+        )
+        spells = ''
+        for spell in self.spells:
+            if spell.faction == self.faction:
+                spells += '[{}]{}{} '.format(
+                    'x' if spell.tapped else ' ',
+                    spell.name,
+                    '+' if spell.artwork and not spell.artwork.hex else '',
+                )
+        spells = spells or 'No spells'
+        return '{} : {} : {}'.format(turn, actions, spells)
+
+    def flush_msg(self, msg):
+        print('flush: {}'.format(msg))
+        self.screen.info.text = msg
 
     def get_placed_objects(self):
         # return all objects currently placed on board
@@ -283,12 +294,13 @@ class Board(object):
         self.flush_aura_data()
         self.flush_player_data()
         self.flush_artwork_data()
-
+        self.screen.board_state.text = self.current_board.get_state_msg()
 
 
     ##########################
     # string to object methods
     ##########################
+    # TODO: remove these when Operation is removed
 
     """
     Params: string should be one of [1 5 q t a g z d l]

--- a/backend/game.py
+++ b/backend/game.py
@@ -166,7 +166,7 @@ class Game(object):
             b_spell = self.get_current_player().hex.room.bewitchment
 
             spells = [a_spell, b_spell, None]
-            print('You have the option to choose a spell (if you do, your opponent will recieve the other spell)')
+            # print('You have the option to choose a spell (if you do, your opponent will recieve the other spell)')
             chosen_spell = screen_input.choose_from_list(self.screen, spells)
 
             if chosen_spell != None:
@@ -182,7 +182,7 @@ class Game(object):
             raise InvalidMove('You cannot end turn with negative actions, please reset turn and try again')
         self.maybe_claim_spell()
 
-        print('ENDING TURN')
+        # print('ENDING TURN')
         self.current_board.end_turn()
         self.old_board = copy.deepcopy(self.current_board)
 
@@ -220,6 +220,7 @@ class Game(object):
             # print(self)
             self.current_board.flush_gamepieces()
             move_type = screen_input.choose_move(self.screen)
+            self.screen.info.error = None
             try:
                 if move_type == 'move':
                     self.move()
@@ -235,19 +236,19 @@ class Game(object):
                     self.end_turn()
                 elif move_type == 'reset turn':
                     self.reset_turn()
-                elif move_type == 'end':
+                elif move_type == 'end game':
                     current_faction = self.current_board.faction
-                    print('{} forefits, {} wins!'.format(current_faction, other_faction(current_faction)))
+                    self.screen.info.text = '{} forefits, {} wins!'.format(current_faction, other_faction(current_faction))
                     break
                 print(self)
             except InvalidMove as move:
                 print(self)
-                print('{} '.format(move))
+                self.screen.info.error = '{} '.format(move)
         # at this point, self.is_game_over()
         print("{} wins!".format(self.is_game_over()))
         print("Click on any hex to exit.")
         screen_input.get_click(self.screen)
-        print('Goodbye :)\n')        
+        print('Goodbye :)\n')
 
 
 if __name__ == "__main__":

--- a/backend/spell.py
+++ b/backend/spell.py
@@ -10,9 +10,9 @@ import graphics.screen_input as screen_input
 from copy import deepcopy
 import backend.location as location
 
-""" 
+"""
 method to place auras on hexes, used in Imposter and Upset
-place_auras_on_hexes replaces the auras on the hexes in hex_list with 
+place_auras_on_hexes replaces the auras on the hexes in hex_list with
 those in aura_list, based on user input
 
 Params:
@@ -52,11 +52,7 @@ class Spell(object):
         self.tapped = False
 
     def __str__(self):
-        return '{name}\t({faction}:{tapped})'.format(
-            name = self.name,
-            faction = self.faction or 'No faction',
-            tapped = 'Tapped' if self.tapped else 'Untapped',
-        )
+        return self.name
 
     def untap(self):
         """Used in Board.end_turn to reset spell states"""
@@ -183,7 +179,7 @@ class Imposter(Spell):
         target_room = choose_from_list(
             board.screen,
             location.linked_rooms(board, self.artwork.hex),
-            prompt_text = 'Choose room to copy to',
+            prompt_text = 'Choose room to copy to:',
         )
         # get list of auras in artwork's room
         aura_list = [hex.aura for hex in self.artwork.hex.room.hexes if hex.aura]
@@ -464,7 +460,7 @@ class Yeoman(Spell):
         self._validate_artwork_status(board)
         # get linked rooms
         populated_linked_rooms = location.linked_rooms(board, self.artwork.hex)
-        # for each room, find the objects in the room. 
+        # for each room, find the objects in the room.
         # If there are no objects, remove the room from the list,
         # so that only populated rooms remain
         for room in populated_linked_rooms:
@@ -481,7 +477,7 @@ class Yeoman(Spell):
                 # assign a new location to the object on this hex, if there is one
                 # this assignment goes into object_location_pairs
                 if hex.occupant:
-                    # choose a hex not yet targeted 
+                    # choose a hex not yet targeted
                     target_hex_index = screen_input.choose_hexes(
                         board.screen,
                         [location.find_hex(board,loc) for loc in unoccupied_locations],
@@ -496,7 +492,7 @@ class Yeoman(Spell):
             for object_to_place, loc in object_location_pairs:
                 target_hex = location.find_hex(board, loc)
                 target_hex.occupant = object_to_place
-                object_to_place.hex = target_hex 
+                object_to_place.hex = target_hex
         self._toggle_tapped()
 
 
@@ -539,7 +535,7 @@ class Yoke(Spell):
                     possible_location_data.append((player_destination, target_destination))
             # if there's more than one direction, ask user for input
             player_direction = screen_input.choose_hexes(
-                board.screen, 
+                board.screen,
                 [x[0] for x in possible_location_data],
                 prompt_text="Choose the destination of the player"
             )

--- a/graphics/button.py
+++ b/graphics/button.py
@@ -1,0 +1,128 @@
+"""
+Used to display clickable buttons on the screen
+
+Color and font properties are currently hard coded
+"""
+
+import pygame as pg
+
+BLACK     = (  0,   0,   0)
+WHITE     = (255, 255, 255)
+DARKGRAY  = ( 64,  64,  64)
+GRAY      = (128, 128, 128)
+LIGHTGRAY = (212, 208, 200)
+BUTTON_COLOR = pg.Color("lightblue1")
+DISABLED_COLOR = pg.Color("snow2")
+
+FONT = "Arial"
+FONT_SIZE = 24
+
+class Button(object):
+    def __init__(self, rect, text, keybinding, screen, disabled=False):
+        # text is both what the button displays
+        # and what it returns if clicked / keybinding is pressed
+        self.rect = rect
+        self.text = text
+        self.error = None
+        self.keybinding = keybinding # typing this will 'click' button
+        self.screen = screen # screen obj to draw on
+        self.disabled = disabled
+
+        self.color = BUTTON_COLOR
+        self.disabled_color = DISABLED_COLOR
+        self.text_color = BLACK
+        self.font = pg.font.SysFont(FONT, FONT_SIZE)
+
+        # state of button
+        self.clicked = False
+        self.hovered = False
+        self.lastMouseDownOverButton = False
+
+        # surface objs for each button state
+        self.surfaceNormal = pg.Surface(self.rect.size)
+        self.surfaceDisabled = pg.Surface(self.rect.size)
+        self.versions = [self.surfaceNormal, self.surfaceDisabled]
+
+        # TODO: add mouseover behavior
+        # self.surfaceDown = pg.Surface(self.rect.size)
+        # self.surfaceHighlight = pg.Surface(self.rect.size)
+
+    def handle_event(self, event):
+        if self.disabled:
+            return None
+
+        if event.type == pg.MOUSEBUTTONDOWN:
+            if self.rect.collidepoint(event.pos):
+                return self.text
+            else:
+                return None
+        elif event.type == pg.KEYDOWN:
+            if pg.key.name(event.key) == self.keybinding:
+                return self.text
+            else:
+                return None
+
+    def draw(self):
+        if self.disabled:
+            self.screen.blit(self.surfaceDisabled, self.rect)
+        else:
+            self.screen.blit(self.surfaceNormal, self.rect)
+
+    def render_text(self):
+        if self.keybinding:
+            text = '{} ({})'.format(self.text, self.keybinding)
+        else:
+            text = self.text
+
+        antialias = True
+        w = self.rect.width
+        h = self.rect.height
+
+        surf1 = self.font.render(text, antialias, self.text_color)
+        rect1 = surf1.get_rect()
+        rect1.center = int(w / 2), int(h / 2)
+
+        # render second line with error text
+        if self.error:
+            rect1.center = int(w / 2), int(h / 3)
+
+            surf2 = self.font.render(self.error, antialias, self.text_color)
+            rect2 = surf2.get_rect()
+            rect2.center = int(w / 2), int(3*h / 4)
+            self.surfaceNormal.blit(surf2, rect2)
+            self.surfaceDisabled.blit(surf2, rect2)
+
+
+        self.surfaceNormal.blit(surf1, rect1)
+        self.surfaceDisabled.blit(surf1, rect1)
+
+    def render_bevel(self, surface):
+        w = self.rect.width
+        h = self.rect.height
+
+        pg.draw.line(surface, WHITE, (1, 1), (w - 2, 1))
+        pg.draw.line(surface, WHITE, (1, 1), (1, h - 2))
+        pg.draw.line(surface, DARKGRAY, (1, h - 1), (w - 1, h - 1))
+        pg.draw.line(surface, DARKGRAY, (w - 1, 1), (w - 1, h - 1))
+        pg.draw.line(surface, GRAY, (2, h - 2), (w - 2, h - 2))
+        pg.draw.line(surface, GRAY, (w - 2, 2), (w - 2, h - 2))
+
+
+    def update(self):
+        # TODO: loop over views instead of duplicating code
+        # fill background color for all buttons
+        self.surfaceNormal.fill(self.color)
+        self.surfaceDisabled.fill(self.disabled_color)
+
+        w = self.rect.width
+        h = self.rect.height
+
+        # draw caption text for all buttons
+        self.render_text()
+
+        # normal button gets black border with bevel
+        pg.draw.rect(self.surfaceNormal, BLACK, pg.Rect((0, 0, w, h)), 1)
+        self.render_bevel(self.surfaceNormal)
+
+        # disabled button gets black border
+        pg.draw.rect(self.surfaceDisabled, BLACK, pg.Rect((0, 0, w, h)), 1)

--- a/graphics/screen_input.py
+++ b/graphics/screen_input.py
@@ -12,7 +12,6 @@ def get_keypress(screen):
             continue
         else:
           keypress = screen.key
-          screen.key = None
           return keypress
 
 def get_click(screen):
@@ -23,7 +22,6 @@ def get_click(screen):
             continue
         else:
           axial_pos = screen.click_hex
-          screen.click_hex = None
           return axial_pos
 
 def choose_move(screen):
@@ -31,50 +29,35 @@ def choose_move(screen):
     Params: none
     Returns: string representation of the move to make
     '''
-    while True:
-        print('> Would you like to (1) move (2) bless (3) drop (4) pick up (5) cast spell (6) end turn (7) restart turn or (8) end game? ')
-        move_type = get_keypress(screen)
 
-        if move_type == '1':
-            return 'move'
-        elif move_type == '2':
-            return 'bless'
-        elif move_type == '3':
-            return 'drop'
-        elif move_type == '4':
-            return 'pick up'
-        elif move_type == '5':
-            return 'cast spell'
-        elif move_type == '6':
-            return 'end turn'
-        elif move_type == '7':
-            return 'reset turn'
-        elif move_type == '8':
-            return 'end'
-        else:
-            print('Please enter a number 1-8')
+    screen.info.text = 'Select option (click button or use keybinding)'
+    return get_keypress(screen)
 
 '''
 Params: list of objects
 Returns: chosen object
 '''
-def choose_from_list(screen, ls, prompt_text=None):
+def choose_from_list(screen, ls, prompt_text='Choose one:'):
     if len(ls) == 0:
         return None
     elif len(ls) == 1:
         return ls[0]
-    if prompt_text:
-        # print optional prompt
-        print(prompt_text)
+
+    prompt = prompt_text
+    for idx, obj in enumerate(ls):
+        prompt += ' ({}) {}'.format(idx + 1, obj)
+
+    screen.info.text = prompt
+    screen.toggle_action_buttons()
     while True:
-        for idx, obj in enumerate(ls):
-            print(' ({}) {}'.format(idx + 1, obj))
-        print('> Which do you want? ')
         choice = get_keypress(screen)
         try:
-            return ls[int(choice) - 1]
+            ret = ls[int(choice) - 1]
+            screen.toggle_action_buttons()
+            screen.info.error = None
+            return ret
         except (ValueError, IndexError):
-            print('Please a number 1-{}'.format(len(ls) + 1))
+            screen.info.error = 'Please enter a number 1-{}'.format(len(ls))
 
 """
 Choose a location based on clicking a hex
@@ -91,16 +74,19 @@ def choose_location(screen, axial_pos, prompt_text="Click a location"):
         return None
     elif len(axial_pos) == 1:
         return 0
-    if prompt_text:
-        # print optional prompt
-        print(prompt_text)
 
+    # set prompt
+    screen.info.text = prompt_text
+    screen.toggle_action_buttons()
     while True:
         pos = get_click(screen)
         if pos in axial_pos:
-            return  axial_pos.index(pos)
+            ret = axial_pos.index(pos)
+            screen.info.error = None
+            screen.toggle_action_buttons()
+            return ret
         else:
-            print('Please click one of {}'.format(axial_pos))
+            screen.info.error = 'Please click one of {}'.format(axial_pos)
 
 """
 Choose a location from a list of hexes based on clicking a hex


### PR DESCRIPTION
board
 - makes L room the right shape
 - moves P room to legal position
 - add `get_state_msg` to get the text to display board state on screen

screen
 - tiles are now regular hexagons
 - tiles are centered on screen
 - screen is bigger
 - 8 buttons at the top of the screen for the basic options, each with keybindings
 - box displaying board state: whose turn, # actions, spells of current player
 - box for prompt text + error messages

screen input
 - changes all `print`s to display on screen instead

game 
 - changes some `print`s to display on screen instead

spell
 - printing a spell only prints the name, not faction and tapped state
