### PR TITLE
Show spell info on screen

### DIFF
--- a/backend/board.py
+++ b/backend/board.py
@@ -147,16 +147,7 @@ class Board(object):
             self.actions,
             '' if self.actions == 1 else 's',
         )
-        spells = ''
-        for spell in self.spells:
-            if spell.faction == self.faction:
-                spells += '[{}]{}{} '.format(
-                    'x' if spell.tapped else ' ',
-                    spell.name,
-                    '+' if spell.artwork and not spell.artwork.hex else '',
-                )
-        spells = spells or 'No spells'
-        return '{} : {} : {}'.format(turn, actions, spells)
+        return '{}, {}'.format(turn, actions)
 
     def get_placed_objects(self):
         # return all objects currently placed on board
@@ -229,6 +220,18 @@ class Board(object):
                 })
         self.screen.make_map(hex_maps)
 
+    def flush_spell_data(self):
+        data = []
+        for spell in self.spells:
+            data.append({
+                'name': spell.name,
+                'description': spell.description,
+                'faction': spell.faction,
+                'tapped': spell.tapped,
+                'artwork': bool(spell.artwork and not spell.artwork.hex)
+            })
+        self.screen.make_spells(data)
+
     def flush_player_data(self):
         data = []
         for player in self.players.values():
@@ -267,4 +270,9 @@ class Board(object):
         self.flush_aura_data()
         self.flush_player_data()
         self.flush_artwork_data()
-        self.screen.board_state.text = self.get_state_msg()
+        self.flush_spell_data()
+        self.screen.board_state.text = '{}\'s turn'.format(self.faction)
+        self.screen.board_state.error = '{} action{} left'.format(
+            self.actions,
+            '' if self.actions == 1 else 's',
+        )

--- a/backend/spell.py
+++ b/backend/spell.py
@@ -277,7 +277,7 @@ class Shovel(Spell):
         super(Shovel, self).__init__() # initializes faction and tapped
         self.name = 'Shovel'
         self.color = 'Sapphire'
-        self.description = "Move Shovel room to adjacent space,\n or if you\'re on it, move Shovel room anywhere"
+        self.description = "Move Shovel room to adjacent space, or if you\'re on the Shovel move it anywhere"
 
     def create_Shovel_room(self, location):
         return Room("Shovel",
@@ -286,7 +286,7 @@ class Shovel(Spell):
             )
 
     def cast(self, board):
-        self._validate_spell_status()
+        self._validate_spell_status(board)
 
         # check if the shovel has been placed yet
         if len(board.rooms) == 7:

--- a/graphics/button.py
+++ b/graphics/button.py
@@ -2,6 +2,9 @@
 Used to display clickable buttons on the screen. Buttons change color
 on hover, can be disabled, and can also be "clicked" via a keybinding.
 
+This file also has the TextBox class which displays 1-2 lines of text
+and an additional description on hover.
+
 Color and font properties are hard coded.
 """
 import pygame as pg
@@ -24,7 +27,6 @@ class Button(object):
         # and what it returns if clicked / keybinding is pressed
         self.rect = rect
         self.text = text
-        self.error = None # displays as a second line under text
         self.keybinding = keybinding # typing this will "click" button
         self.screen = screen # screen obj to draw on
         self.disabled = disabled
@@ -70,8 +72,7 @@ class Button(object):
         else:
             self.screen.blit(self.surfaceNormal, self.rect)
 
-    # adds 1 (if not self.error) or 2 (if self.error) lines of text to the button surface
-    def render_text(self, surface):
+    def render_text_all_surfaces(self):
         if self.keybinding:
             text = '{} ({})'.format(self.text, self.keybinding)
         else:
@@ -84,22 +85,12 @@ class Button(object):
         text_rect = text_surface.get_rect()
         text_rect.center = int(w / 2), int(h / 2) # center text on button
 
-        # render second line with error text
-        if self.error:
-            text_rect.center = int(w / 2), int(h / 3) # place text above button center
-
-            error_surface = self.font.render(self.error, antialias, self.text_color)
-            error_rect = error_surface.get_rect()
-            error_rect.center = int(w / 2), int(3*h / 4) # place text below button center
-
         for version in self.versions:
             version.blit(text_surface, text_rect)
 
-            if self.error:
-                version.blit(error_surface, error_rect)
-
     def render_bevel(self, surface):
         w, h = self.rect.size
+        pg.draw.rect(surface, DARKGRAY, pg.Rect((0, 0), self.rect.size), 1) # outline
         pg.draw.line(surface, WHITE, (1, 1), (w - 2, 1))
         pg.draw.line(surface, WHITE, (1, 1), (1, h - 2))
         pg.draw.line(surface, DARKGRAY, (1, h - 1), (w - 1, h - 1))
@@ -109,14 +100,54 @@ class Button(object):
 
     def render_button(self, surface, color, bevel=True):
         surface.fill(color)
-        pg.draw.rect(surface, BLACK, pg.Rect((0, 0), self.rect.size), 1) # black outline
         if bevel:
             self.render_bevel(surface)
 
     def update(self):
         self.render_button(self.surfaceNormal, BUTTON_COLOR)
-        self.render_button(self.surfaceDisabled, DISABLED_COLOR, bevel=False)
+        self.render_button(self.surfaceDisabled, DISABLED_COLOR)
         self.render_button(self.surfaceHover, HOVER_COLOR)
 
-        for surface in self.versions:
-            self.render_text(surface)
+        self.render_text_all_surfaces()
+
+class TextBox(object):
+    def __init__(self, rect, screen):
+        self.rect = rect
+        self.text = ''
+        self.error = None # displays as a second line under text
+        self.screen = screen # screen obj to draw on
+
+        self.color = DISABLED_COLOR
+        self.text_color = BLACK
+        self.font = pg.font.SysFont(FONT, FONT_SIZE)
+
+        self.surface = pg.Surface(self.rect.size)
+
+    # adds 1 (if not self.error) or 2 (if self.error) lines of text to the button surface
+    def render_text(self):
+        antialias = True
+        w, h = self.rect.size # button dimensions
+
+        text_surface = self.font.render(self.text, antialias, self.text_color)
+        text_rect = text_surface.get_rect()
+        text_rect.center = int(w / 2), int(h / 2) # center text on button
+
+        # render second line with error text
+        if self.error:
+            text_rect.center = int(w / 2), int(h / 3) # place text above button center
+
+            error_surface = self.font.render(self.error, antialias, self.text_color)
+            error_rect = error_surface.get_rect()
+            error_rect.center = int(w / 2), int(3*h / 4) # place text below button center
+            self.surface.blit(error_surface, error_rect)
+
+        # wait until here to render text so that it can be moved down if self.error
+        self.surface.blit(text_surface, text_rect)
+
+    def draw(self):
+        self.screen.blit(self.surface, self.rect)
+
+    def update(self):
+        self.surface.fill(self.color)
+        pg.draw.rect(self.surface, DARKGRAY, pg.Rect((0, 0), self.rect.size), 1) # outline
+        self.render_text()

--- a/graphics/spell.py
+++ b/graphics/spell.py
@@ -1,0 +1,129 @@
+"""
+Used to display spell info on the screen. Hovering over a spell shows its
+description, and spells also show their faction, artwork, and tapped state.
+
+Color and font properties are hard coded.
+"""
+import pygame as pg
+
+# TODO: dont dup colors from screen
+ROOM_COLORS = {
+    "P" : pg.Color("pink"),
+    "I" : pg.Color("slateblue"),
+    "O" : pg.Color("orange"),
+    "U" : pg.Color("saddlebrown"),
+    "S" : pg.Color("turquoise2"),
+    "L" : pg.Color("yellowgreen"),
+    "Y" : pg.Color("yellow2"),
+}
+
+TRANSPARENT = (0, 0, 0, 0)
+BLACK     = (  0,   0,   0)
+WHITE     = (255, 255, 255)
+DARKGRAY  = ( 64,  64,  64)
+GRAY      = (128, 128, 128)
+LIGHTGRAY = (212, 208, 200)
+
+FACTION_COLORS = {
+    "Dark": BLACK,
+    "Light": WHITE,
+    None: pg.Color("snow2"),
+}
+
+FONT = "Arial"
+FONT_SIZE = 24
+
+class Spell(object):
+    def __init__(self, rect, name, description, description_pos, faction, artwork, tapped, screen):
+        self.rect = rect
+        self.name = name
+        self.description = description
+        self.description_pos = description_pos
+        self.screen = screen # screen obj to draw on
+        self.faction = faction
+        self.unplaced_artwork = artwork
+        self.tapped = tapped
+        self.hovered = False
+
+        self.text_color = BLACK
+        self.font = pg.font.SysFont(FONT, FONT_SIZE)
+
+        # surface objs for spell
+        self.surface = pg.Surface(self.rect.size)
+        self.spell_label = None
+        self.spell_label_rect = None
+
+    def handle_event(self, event):
+        if event.type == pg.MOUSEMOTION:
+            if self.rect.collidepoint(event.pos):
+                self.hovered = True
+            else:
+                self.hovered = False
+
+    def render_text(self):
+        antialias = True
+
+        # write spell name on spell box
+        w, h = self.rect.size # spell box dimensions
+        text_surface = self.font.render(self.name, antialias, self.text_color)
+        text_rect = text_surface.get_rect()
+
+        # faction indicator extends 3*h2 into the box - center text in remaining space
+        # h2 = int(h / 2)
+        # text_width = w - 3*h2
+        # text_rect.center = (3*h2 + int(text_width / 2), h2)
+        # self.surface.blit(text_surface, text_rect)
+
+        # left align text a bit in from left of box, center vertically
+        h2 = int(h / 2)
+        text_rect.midleft = (5, h2)
+        self.surface.blit(text_surface, text_rect)
+
+        # write spell description at description_pos
+        description_txt = ' {}'.format(self.description)
+        self.spell_label = self.font.render(description_txt, antialias, self.text_color)
+        self.spell_label_rect = self.spell_label.get_rect(topleft=self.description_pos)
+
+    def draw(self):
+        self.screen.blit(self.surface, self.rect)
+        if self.hovered:
+            self.screen.blit(self.spell_label, self.spell_label_rect)
+
+    def update(self):
+        # background
+        self.surface.fill(FACTION_COLORS[None])
+
+        # cross out tapped spells
+        if self.tapped:
+            h2 = int(self.rect.height/2)
+            pg.draw.line(self.surface, BLACK, (0, h2), (self.rect.width, h2), 1.5)
+
+        # faction
+        if self.faction:
+            w, h = self.rect.size
+            h2 = int(h/2)
+
+            # left flag
+            # points = [(0, 0), (0, h), (h2, h), (3*h2, h2), (h2, 0)]
+
+            # right flag
+            points = [(w, 0), (w, h), (w-h2, h), (w-3*h2, h2), (w-h2, 0)]
+
+            pg.draw.polygon(self.surface, FACTION_COLORS[self.faction], points, 0)
+            pg.draw.polygon(self.surface, BLACK, points, 1) # outline
+
+        # artwork
+        if self.unplaced_artwork:
+            color = ROOM_COLORS[self.name[0]]
+            other_color = BLACK
+            radius = 10
+            pad = int(self.rect.height/2)
+            center = (self.rect.width - pad, pad)
+            pg.draw.circle(self.surface, other_color, center, radius+1) # outline
+            pg.draw.circle(self.surface, color, center, radius)
+
+        # outline on spell name rectangle
+        pg.draw.rect(self.surface, DARKGRAY, pg.Rect((0, 0), self.rect.size), 1)
+
+        # text last so it is on top
+        self.render_text()


### PR DESCRIPTION
backend
 - add `flush_spell_data()` to `Board` 
 - improve `Shovel` description + fix small bug

graphics
 - define `TextBox` class that is separate from `Button` and remove hacky code from `Button`
 - define `Spell` class to display spell state on screen
 - rearrange screen
   - 8 buttons on bottom with 1px space between them
   - text info on the top
   - spells on the right